### PR TITLE
Support laravel/passport 7

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
         }
     ],
     "require": {
-        "laravel/passport": "4.0 - 6.0"
+        "laravel/passport": "4.0 - 7.0"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
[![JIRA Status](https://img.shields.io/endpoint.svg?url=https%3A%2F%2Fprobot-netsells.node.ns-client.xyz%2Fpassport-7)](https://netsells.atlassian.net/browse/passport-7)

This package extends CheckClientCredentials Passport middleware. There are no changes in this class between Passport 6 and 7 packages. Therefore I only updated the composer.json file.