### PR TITLE
Added support for laravel/passport 7.5

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
         }
     ],
     "require": {
-        "laravel/passport": "4.0 - 7.0"
+        "laravel/passport": "4.0 - 7.5"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
         }
     ],
     "require": {
-        "laravel/passport": "4.0 - 7.5"
+        "laravel/passport": "6.0.7 - 7.5"
     },
     "autoload": {
         "psr-4": {

--- a/src/Middleware/CheckClientCredentials.php
+++ b/src/Middleware/CheckClientCredentials.php
@@ -128,7 +128,7 @@ class CheckClientCredentials extends LaravelCheckClientCredentials
     protected function decodeJwtTokenCookie($request)
     {
         return (array) JWT::decode(
-            $this->encrypter->decrypt($request->cookie(config('passport-client-cookie.cookie_name', 'laravel_client_token'))),
+            $this->encrypter->decrypt($request->cookie(config('passport-client-cookie.cookie_name', 'laravel_client_token')), false),
             $this->encrypter->getKey(), ['HS256']
         );
     }


### PR DESCRIPTION
[![JIRA Status](https://img.shields.io/endpoint.svg?url=https%3A%2F%2Fprobot-netsells.node.ns-client.xyz%2Fpassport-7)](https://netsells.atlassian.net/browse/passport-7)

The package supports Laravel Passport 7.5, which contains changes for compatibility with Laravel 5.8