### PR TITLE
Enforce use of PSR HTTP Message Bridge v1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,8 @@
         }
     ],
     "require": {
-        "laravel/passport": "6.0.7 - 8.5"
+        "laravel/passport": "6.0.7 - 8.5",
+        "symfony/psr-http-message-bridge": "^1.0"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
## Overview
- [x] I have performed a self review of my code
- [ ] I have made corresponding changes to the documentation
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added sufficient logging
<!-- Remove the below if this project doesn't have tests (maybe it should?) -->
- [ ] New and existing tests pass locally with my changes
- [ ] The code modified as part of this PR has been covered with tests

### Problem statement
In version 8.4.1 of laravel/passport, [this commit](https://github.com/laravel/passport/pull/1201/files) bumps the version of the psr http message bridge to v2. This introduces a breaking change to our package as we do not directly require the bridge, even though it is relied on.
The call to the DiactorosFactory is deprecated in v1 and removed in v2. As it is removed, this package cannot use v2 and therefor cannot support 8.4.1+ in its current state.

### Solution
This change force the use of v1, effectively locking the available version range of passport to 6 - 8.4.0.
To go beyond version 8.4, another PR is required to fix this breaking change and would require version 2.0 of this package.

Suggest that this change is released as 1.1.1.

### Dependencies
N/A

### Test procedures
Can be tested in live projects where passport 8.5 is in use.

### Links

JIRA: https://netsells.atlassian.net/browse/WMBT-146

## Deployment

### Migrations
No

### Environment variables
<!-- A list of any new/changed environment variables and where to find the correct value -->
<!-- Don't put keys in here. Place them in 1password or Slack -->

### Deployment notes
<!-- Any additional notes about deployment, such as one-off artisan commands that should be run or new cron jobs -->
