### PR TITLE
Support Passport 8.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,33 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
+and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
+
+    Given a version number MAJOR.MINOR.PATCH, increment the:
+
+    * MAJOR version when you make incompatible API changes,
+    * MINOR version when you add functionality in a backwards-compatible manner, and
+    * PATCH version when you make backwards-compatible bug fixes.
+
+## Major Versions
+* [1.0](#100---2019-12-04) - Initial Version
+
+## Unreleased
+## Added
+- Support for Passport ^8.4.1 & ^9.0
+
+## Removed
+- Support for Passport < 8.4.1
+
+## [1.1.0] - 2020-10-14
+## Added
+- Support for Passport 8
+
+## [1.0.0] - 2019-12-04
+## Added
+- Support for Passport 6.0.7 - 7.5
+
+[Unreleased]: https://github.com/netsells/hatchly-platform/compare/1.1.0...HEAD
+[1.1.0]: https://github.com/netsells/hatchly-platform/compare/1.0.0...1.1.0
+[1.0.0]: https://github.com/netsells/hatchly-platform/compare/1.0.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## Added
 - Support for Passport 6.0.7 - 7.5
 
-[Unreleased]: https://github.com/netsells/hatchly-platform/compare/1.1.0...HEAD
+[Unreleased]: https://github.com/netsells/hatchly-platform/compare/1.1.1...HEAD
+[1.1.1]: https://github.com/netsells/hatchly-platform/compare/1.1.0...1.1.1
 [1.1.0]: https://github.com/netsells/hatchly-platform/compare/1.0.0...1.1.0
 [1.0.0]: https://github.com/netsells/hatchly-platform/compare/1.0.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## Removed
 - Support for Passport < 8.4.1
 
+## [1.1.1] - 2020-11-09
+## Added
+- Requirement for PSR Message Bridge v1
+
 ## [1.1.0] - 2020-10-14
 ## Added
 - Support for Passport 8

--- a/composer.json
+++ b/composer.json
@@ -9,8 +9,8 @@
         }
     ],
     "require": {
-        "laravel/passport": "6.0.7 - 8.5",
-        "symfony/psr-http-message-bridge": "^1.0"
+        "laravel/passport": "^8.4.1 || ^9.0",
+        "symfony/psr-http-message-bridge": "^2.0"
     },
     "autoload": {
         "psr-4": {

--- a/src/Middleware/CheckClientCredentials.php
+++ b/src/Middleware/CheckClientCredentials.php
@@ -7,10 +7,14 @@ use Firebase\JWT\JWT;
 use Illuminate\Auth\AuthenticationException;
 use Illuminate\Contracts\Encryption\Encrypter;
 use Illuminate\Foundation\Application;
+use Laminas\Diactoros\ResponseFactory;
+use Laminas\Diactoros\ServerRequestFactory;
+use Laminas\Diactoros\StreamFactory;
+use Laminas\Diactoros\UploadedFileFactory;
 use Laravel\Passport\Http\Middleware\CheckClientCredentials as LaravelCheckClientCredentials;
 use League\OAuth2\Server\Exception\OAuthServerException;
 use League\OAuth2\Server\ResourceServer;
-use Symfony\Bridge\PsrHttpMessage\Factory\DiactorosFactory;
+use Symfony\Bridge\PsrHttpMessage\Factory\PsrHttpFactory;
 
 class CheckClientCredentials extends LaravelCheckClientCredentials
 {
@@ -77,7 +81,12 @@ class CheckClientCredentials extends LaravelCheckClientCredentials
 
     private function authenticateViaBearerToken($request)
     {
-        $psr = (new DiactorosFactory)->createRequest($request);
+        $psr = (new PsrHttpFactory(
+            new ServerRequestFactory(),
+            new StreamFactory(),
+            new UploadedFileFactory(),
+            new ResponseFactory()
+        ))->createRequest($request);
 
         try {
             $psr = $this->server->validateAuthenticatedRequest($psr);


### PR DESCRIPTION
[![JIRA Status](https://img.shields.io/endpoint.svg?url=https%3A%2F%2Fprobot-netsells.node.ns-client.xyz%2Fbadge%2Fpassport-8)](https://netsells.atlassian.net/browse/passport-8)

## Overview
- [x] I have performed a self review of my code
- [ ] I have made corresponding changes to the documentation
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added sufficient logging
<!-- Remove the below if this project doesn't have tests (maybe it should?) -->
- [ ] New and existing tests pass locally with my changes
- [ ] The code modified as part of this PR has been covered with tests

### Problem statement
The DiactorosFactory was deprecated in v1 of the http bridge and removed in v2.

### Solution
This replaces the factory with the suggested replacement. See [this PR](https://github.com/laravel/passport/commit/aadf603c1f45cfa4bbf954bfc3abc30cdd572683) for how passport handled the change.
This is a breaking change.

### Dependencies
<!-- Other PRs that this PR depends on -->

### Test procedures
<!-- Step by step guide for testing this PR -->

### Links

JIRA: https://netsells.atlassian.net/browse/WMBT-146

## Deployment

### Migrations
No

### Environment variables
<!-- A list of any new/changed environment variables and where to find the correct value -->
<!-- Don't put keys in here. Place them in 1password or Slack -->

### Deployment notes
<!-- Any additional notes about deployment, such as one-off artisan commands that should be run or new cron jobs -->
