### PR TITLE
Add composer requirement for diactoros

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 * [1.0](#100---2019-12-04) - Initial Version
 
 ## Unreleased
+### Added
+- Adds composer requirement for Diactoros package
+
 ## [2.1.0] - 2021-06-16
 ### Added
 - Support for Passport ^10.0

--- a/composer.json
+++ b/composer.json
@@ -10,6 +10,7 @@
     ],
     "require": {
         "laravel/passport": "^8.4.1 || ^9.0 || ^10.0",
+        "laminas/laminas-diactoros": "^2.2",
         "symfony/psr-http-message-bridge": "^2.0"
     },
     "autoload": {


### PR DESCRIPTION
## Overview
Adds composer requirement for diactoros.

This package has been required for the client cookie to work correctly and has previously always been included with Passport. Passport 10 no longer requires this package which causes the client cookie to break.
